### PR TITLE
htmx also in backend, preserve linebreaks in textarea

### DIFF
--- a/classes/class-hxwp-main.php
+++ b/classes/class-hxwp-main.php
@@ -59,6 +59,7 @@ class HXWP_Main
 		add_action('init', [$router, 'register_main_route']);
 		add_action('template_redirect', [$render, 'load_template']);
 		add_action('wp_enqueue_scripts', [$assets, 'enqueue_scripts']);
+		add_action('admin_enqueue_scripts', [$assets, 'enqueue_scripts']);
 		add_action('wp_head', [$config, 'insert_config_meta_tag']);
 
 		if (is_admin()) {

--- a/classes/class-hxwp-render.php
+++ b/classes/class-hxwp-render.php
@@ -216,7 +216,7 @@ class HXWP_Render
 			$key = apply_filters('hxwp/sanitize_param_key', sanitize_key($key), $key);
 
 			// Sanitize value and apply filter in one line
-			$value = apply_filters('hxwp/sanitize_param_value', sanitize_text_field($value), $value);
+			$value = apply_filters('hxwp/sanitize_param_value', sanitize_textarea_field($value), $value);
 
 			// Update param
 			$hxvals[$key] = $value;


### PR DESCRIPTION
two changes that I needed for myself but I assume they could be helpful for others:
* for the sanitization of input fields, using `sanitize_textarea_field($value), $value);` because otherwise in textareas the linebreaks (and tabs etc.) are not transferred, but people need those.
* I added `add_action('admin_enqueue_scripts', [$assets, 'enqueue_scripts']);` such that htmx is available on the backend as well.