### PR TITLE
Allow for installation via Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "mwender/htmx-api-wp",
+  "name": "tcattd/htmx-api-wp",
   "description": "An un-official HTMX API for WordPress",
   "keywords": ["wordpress", "plugin", "htmx", "api"],
   "homepage": "https://github.com/TCattd/HTMX-API-WP",

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+  "name": "mwender/htmx-api-wp",
+  "description": "An un-official HTMX API for WordPress",
+  "keywords": ["wordpress", "plugin", "htmx", "api"],
+  "homepage": "https://github.com/TCattd/HTMX-API-WP",
+  "authors": [
+    {
+      "name": "Esteban Cuevas",
+      "homepage": "https://actitud.xyz/"
+    }
+  ],
+  "type": "wordpress-plugin",
+  "require": {
+    "php": ">=8.0"
+  }
+}


### PR DESCRIPTION
Adding a composer.json will allow for users to install this plugin via Composer. 

Once the composer.json is in place within this repository, one will need to add the appropriate repository reference in your project's composer.json:

```
"repositories": {
  "tcattd": {
    "type": "vcs",
    "url": "git@github.com:tcattd/htmx-api-wp.git"
  }
}
```

Then one can run `composer require tcattd/htmx-api-wp` to add the plugin to your project's required dependencies.