### PR TITLE
Fix path to child theme

### DIFF
--- a/classes/class-hxwp-render.php
+++ b/classes/class-hxwp-render.php
@@ -240,10 +240,10 @@ class HXWP_Render
 	 */
 	protected function get_theme_path()
 	{
-		$theme_path = trailingslashit(get_stylesheet_directory());
+		$theme_path = trailingslashit(get_template_directory());
 
 		if (is_child_theme()) {
-			$theme_path = trailingslashit(get_template_directory());
+			$theme_path = trailingslashit(get_stylesheet_directory());
 		}
 
 		return $theme_path;


### PR DESCRIPTION
BUGFIX: Original code was using `get_template_directory()` when `is_child_theme()` returns `TRUE`. This means we would return the "parent" theme directory when using a child theme. 

However, in two projects so far where I have implemented this code with a child theme, my natural expectation is that when using a child theme, I would expect `/htmx-templates/` to be found in the child theme.